### PR TITLE
Removed Python version from Dockerfile to resolve errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu
-FROM python:3.7.3
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Removed Python version from Dockerfile to resolve the following errors that show up when we run `docker build .`
```
autoreconf: Entering directory `.'
autoreconf: running: true
autoreconf: running: aclocal -I m4
autoreconf: configure.ac: tracing
autoreconf: running: true --copy
autoreconf: running: /usr/bin/autoconf
autoreconf: running: /usr/bin/autoheader
autoreconf: running: automake --add-missing --copy --no-force
configure.ac:182: warning: The 'AM_PROG_MKDIR_P' macro is deprecated, and its use is discouraged.
configure.ac:182: You should use the Autoconf-provided 'AC_PROG_MKDIR_P' macro instead,
configure.ac:182: and use '$(MKDIR_P)' instead of '$(mkdir_p)'in your Makefile.am files.
configure.ac:40: installing 'build-aux/compile'
configure.ac:27: installing 'build-aux/missing'
parallel-tests: installing 'build-aux/test-driver'
gnulib/lib/Makefile.am: installing 'build-aux/depcomp'
autoreconf: Leaving directory `.'
CONFIGUREDIR=.
# Run configure in BUILDDIR if it's set
if [ ! -z "$BUILDDIR" ]; then
    mkdir -p $BUILDDIR
    cd $BUILDDIR
    CONFIGUREDIR=..
fi
# Rerun the generator (requires OCaml interpreter).  This is *not* for
# anything that is required at configure-time when configure is run
# from a distribution tarball.  From those, nothing ocaml-related is
# required.
mkdir -p perl/lib/Win
./generator/generator.ml
File "./generator/generator.ml", line 702, characters 26-46:
Error: Unbound value Char.lowercase_ascii
```