### PR TITLE
Fix some leaking memory.

### DIFF
--- a/lib/handle.c
+++ b/lib/handle.c
@@ -720,6 +720,11 @@ hivex_close (hive_h *h)
       h->iconv_cache[t].handle = NULL;
     }
   }
+  while (h->free_blocks != NULL) {
+      unallocated_block *next = h->free_blocks->next;
+      free(h->free_blocks);
+      h->free_blocks = next;
+  }
   free (h);
 
   return r;


### PR DESCRIPTION
We added code to allocate memory in blocks instead of pages,
but never added code to free the data structures we used to manage
it; this commit frees that memory. That memory was definitely being
leaked, it remains to be seen if there are other leaks too.