### PR TITLE
Build updates and fix for memory leak.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,12 @@ Makefile.in
 /stamp-h1
 /xml/*.1
 /xml/hivexml
+/GNUmakefile
+/maint.mk
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     ocaml \
     m4 \
-    libreadline5 \
+    libreadline-dev \
     gettext \
     autopoint \
     cpio \
@@ -38,16 +38,16 @@ RUN apt-get update && apt-get install -y \
     libyara-dev \
     supermin \
     qemu \
-    python \
+    python3 \
     python3-dev \
     perl \
     libperl-dev
 
-RUN rm /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
+RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 
 # build hivex
 RUN cpan install Test::More ExtUtils::MakeMaker IO::Stringy
-RUN git clone https://github.com/rapid7/hivex.git /root/hivex
+COPY . /root/hivex
 WORKDIR "/root/hivex"
 
 RUN ./autogen.sh

--- a/generator/generator.ml
+++ b/generator/generator.ml
@@ -2887,15 +2887,7 @@ get_value (PyObject *v, hive_set_value *ret)
     PyErr_SetString (PyExc_KeyError, \"no 'key' element in dictionary\");
     return -1;
   }
-  if (PyUnicode_Check (obj)) {
-    /* TODO: use PyUnicode_DecodeASCII or PyUnicode_AsUTF16String instead? */
-    bytes = PyUnicode_AsUTF8String (obj);
-    if (bytes == NULL) {
-      PyErr_SetString (PyExc_ValueError, \"failed to decode 'key'\");
-      return -1;
-    }
-    ret->key = PyBytes_AS_STRING (bytes);
-  } else if (PyBytes_Check (obj)) {
+  if (PyBytes_Check (obj)) {
     ret->key = PyBytes_AS_STRING (obj);
   } else {
     PyErr_SetString (PyExc_TypeError, \"expected bytes type for 'key'\");


### PR DESCRIPTION

Dockerfile changes:
* Update to newer versions of some dependencies that don't exist anymore
* Changing so that instead of doing a git checkout in the Dockerfile, it copies the local checkout over; this will simplify development and shouldn't change anything in the production build

Generator change:
* The codepath that converts from unicode string to bytes leaks memory. I couldn't figure out a simple way in the C++ not to leak memory, so I'm removing that codepath and insisting that the calling python code do the conversion first.