### PR TITLE
ENDPOINT-4046: Pin Ubuntu distro to Bionic, revert package names to prevent GLIBC error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:18.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     ocaml \
     m4 \
-    libreadline-dev \
+    libreadline5 \
     gettext \
     autopoint \
     cpio \
@@ -38,12 +38,12 @@ RUN apt-get update && apt-get install -y \
     libyara-dev \
     supermin \
     qemu \
-    python3 \
+    python \
     python3-dev \
     perl \
     libperl-dev
 
-RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
+RUN rm /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 
 # build hivex
 RUN cpan install Test::More ExtUtils::MakeMaker IO::Stringy


### PR DESCRIPTION
Jira ticket is [ENDPOINT-4046](https://issues.corp.rapid7.com/browse/ENDPOINT-4046).
When building the Hivex library into ".so" files (using [these steps](https://wiki.corp.rapid7.com/pages/viewpage.action?spaceKey=PM&title=Building+Hivex+Changes+For+The+Patcher+Service)) and using these files in the patcher service, we were met with an issue:
![Hivex GLIBC issue](https://user-images.githubusercontent.com/83985491/170144334-46297e7f-4c5b-45d1-9df0-0ff2f72bfe33.png)

This was likely due to the `python` package being updated in the Dockerfile for building Hivex. This in turn was needed as the `python` and `libreadline5` packages could no longer be found with apt-get.

Pinning the version of Ubuntu used in the Dockerfile  to 18.04 when building the libraries allows us to use the pre-existing packages, bypassing the GLIBC issue (see [here](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libreadline5&searchon=names) and [here](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python&searchon=names)).

### Testing
Dockerfile builds Hivex container successfully:
![Docker file built](https://user-images.githubusercontent.com/83985491/170144720-240f9bb3-e709-45ca-a3e3-a0072dc53824.png)

Patcher service patches successfully locally when using the new Hivex library files from the container:
![Patcher patching (2)](https://user-images.githubusercontent.com/83985491/170144776-b9ad91e8-6324-439c-8944-220097cb7eb1.png)

Patcher integration tests are successful with new Hivex library files:
![Patcher integration tests](https://user-images.githubusercontent.com/83985491/170144814-1bdb95b8-2cf7-46cc-9fdf-9713a86e7596.png)
